### PR TITLE
backup script

### DIFF
--- a/backup_archives.sh
+++ b/backup_archives.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Replace X with your group number
+GROUP_NUMBER="X"
+ARCHIVE_DIR="archived_logs_group$GROUP_NUMBER"
+REMOTE_USER="d428dceaebce"
+REMOTE_HOST="d428dceaebce.599ec69a.alu-cod.online"
+REMOTE_DIR="/hospital_monitoring_group-4/$REMOTE_USER"
+
+# Create the archive directory if it doesn't exist
+mkdir -p "$ARCHIVE_DIR"
+
+# Move all archived log files to the archive directory
+mv *_archived.log "$ARCHIVE_DIR/"
+
+# Backup the archive directory to the remote server
+scp -r "$ARCHIVE_DIR" "$REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR"
+
+# Check if the scp command was successful
+if [ $? -eq 0 ]; then
+    echo "Backup completed successfully."
+else
+    echo "Backup failed. Please check your connection and try again."
+fi
+


### PR DESCRIPTION
 Archival and Backup Script
Script Name: backup_archives.sh

Description: After archiving the log files, you will now create a script that:
Moves the archived log files into a designated directory called archived_logs_group$. (replace the dollar sign with your group number)
Back up the archived files to a remote server using SSH.
The script should move all archived log files (with timestamped names) into the archived_logs_group$ directory.
Once moved, the files should be securely backed up on a remote server using the scp command via SSH.
Remote Backup Details:

The backup script should first put all the archived log files in archived_logs_group$ directory
Groups will use one of their member's sandbox as a server (sandbox) for backup and use connection details:
Host: copy the host info of the sandbox
Username: copy the username of the sandbox
Directory on the backup server where to send to: /home/
Expected functionalities in Task 3:

Write the backup_archives.sh script to:
Move all archived log files to archived_logs_group$.
Back up the contents of this directory to the remote server using SSH.
Ensure the script is executable and properly handles file transfers.